### PR TITLE
Add more Rubyish bindings as an alternative API

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,9 @@ rvm:
 notifications:
   email:
    - raphael.pinson@camptocamp.com
+  irc:
+    channels:
+      - "irc.freenode.org#augeas"
 install:
   # Use latest Augeas
   - sudo add-apt-repository -y ppa:raphink/augeas

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,12 @@
 language: ruby
 rvm:
+  # CentOS 6 is still stuck on this
   - 1.8.7
   - 1.9.3
+  # CentOS 7 uses Ruby 2.0.0
+  - 2.0.0
+  # This is the latest stable MRI Ruby right now
+  - 2.3.1
 notifications:
   email:
    - raphael.pinson@camptocamp.com

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,3 +10,4 @@ install:
   - sudo add-apt-repository -y ppa:raphink/augeas
   - sudo apt-get update
   - sudo apt-get install libaugeas-dev libxml2-dev
+  - bundle install

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,11 @@
+source 'https://rubygems.org/'
+
+group :development, :test do
+  if RUBY_VERSION == "1.8.7"
+    gem 'rake', "< 1.0.0"
+  else
+    gem "rake"
+    gem 'test-unit'
+  end
+  gem 'rdoc'
+end

--- a/README.md
+++ b/README.md
@@ -1,34 +1,42 @@
-= Ruby bindings for augeas
+# Ruby bindings for augeas
 
-The class Augeas provides bindings to augeas [http://augeas.net] library.
+The class Augeas provides bindings to [Augeas](http://augeas.net) library.
 
-== Usage: Setting Data
+## Usage: Setting Data
+```ruby
     Augeas::open do |aug|
       aug.set("/files/etc/sysconfig/firstboot/RUN_FIRSTBOOT", "YES")
       unless aug.save
         raise IOError, "Failed to save changes"
       end
     end
+```
 
-== Usage: Accessing Data
+## Usage: Accessing Data
+```ruby
     firstboot = Augeas::open { |aug| aug.get("/files/etc/sysconfig/firstboot/RUN_FIRSTBOOT") }
+```
 
-== Usage: Removing Data
+## Usage: Removing Data
+```ruby
     Augeas::open do |aug|
       aug.rm("/files/etc/sysconfig/firstboot/RUN_FIRSTBOOT")
       unless aug.save
         raise IOError, "Failed to save changes"
       end
     end
+```
 
-== Usage: Minimal Setup with a Custom Root
+## Usage: Minimal Setup with a Custom Root
 
 By passing +NO_MODL_AUTOLOAD+, no files are read on startup; that allows
 setting up a custom transform.
 
+```ruby
   Augeas::open("/var/tmp/augeas-root", "/usr/local/share/mylenses",
                 Augeas::NO_MODL_AUTOLOAD) do |aug|
     aug.transform(:lens => "Aliases.lns", :incl => "/etc/aliases")
     aug.load
     aug.get("/files/etc/aliases/*[name = 'postmaster']/value")
   end
+```

--- a/README.md
+++ b/README.md
@@ -2,7 +2,26 @@
 
 The class Augeas provides bindings to [Augeas](http://augeas.net) library.
 
-## Usage: Setting Data
+
+## Building
+
+To build the bindings, which unfortunately includes installing them from a
+gem, you need to have Augeas and its header file installed as well as
+`pkg-config`.
+
+On Fedora, you can do that simply by running
+```
+dnf install augeas-devel pkgconfig
+```
+
+On OSX, you need to set up [Homebrew](http://brew.sh/) and then run
+```
+brew install augeas pkg-config
+```
+
+## Usage
+
+### Setting Data
 ```ruby
     Augeas::open do |aug|
       aug.set("/files/etc/sysconfig/firstboot/RUN_FIRSTBOOT", "YES")
@@ -12,12 +31,12 @@ The class Augeas provides bindings to [Augeas](http://augeas.net) library.
     end
 ```
 
-## Usage: Accessing Data
+### Accessing Data
 ```ruby
     firstboot = Augeas::open { |aug| aug.get("/files/etc/sysconfig/firstboot/RUN_FIRSTBOOT") }
 ```
 
-## Usage: Removing Data
+### Removing Data
 ```ruby
     Augeas::open do |aug|
       aug.rm("/files/etc/sysconfig/firstboot/RUN_FIRSTBOOT")
@@ -27,9 +46,9 @@ The class Augeas provides bindings to [Augeas](http://augeas.net) library.
     end
 ```
 
-## Usage: Minimal Setup with a Custom Root
+### Minimal Setup with a Custom Root
 
-By passing +NO_MODL_AUTOLOAD+, no files are read on startup; that allows
+By passing `NO_MODL_AUTOLOAD`, no files are read on startup; that allows
 setting up a custom transform.
 
 ```ruby

--- a/ext/augeas/_augeas.c
+++ b/ext/augeas/_augeas.c
@@ -176,6 +176,7 @@ VALUE augeas_rm(VALUE s, VALUE path, VALUE sibling) {
 VALUE augeas_match(VALUE s, VALUE p) {
     augeas *aug = aug_handle(s);
     const char *path = StringValueCStr(p);
+    VALUE result;
     char **matches = NULL;
     int cnt, i;
 
@@ -184,7 +185,7 @@ VALUE augeas_match(VALUE s, VALUE p) {
         rb_raise(rb_eSystemCallError, "Matching path expression '%s' failed",
                  path);
 
-    VALUE result = rb_ary_new();
+    result = rb_ary_new();
     for (i = 0; i < cnt; i++) {
         rb_ary_push(result, rb_str_new(matches[i], strlen(matches[i])));
         free(matches[i]) ;
@@ -396,14 +397,15 @@ VALUE augeas_span(VALUE s, VALUE path) {
 VALUE augeas_srun(VALUE s, VALUE text) {
     augeas *aug = aug_handle(s);
     const char *ctext = StringValueCStr(text);
-
+    int r;
+    VALUE result;
     struct memstream ms;
     __aug_init_memstream(&ms);
 
-    int r = aug_srun(aug, ms.stream, ctext);
+    r = aug_srun(aug, ms.stream, ctext);
     __aug_close_memstream(&ms);
 
-    VALUE result = rb_ary_new();
+    result = rb_ary_new();
     rb_ary_push(result, INT2NUM(r));
     rb_ary_push(result, rb_str_new2(ms.buf));
 

--- a/ext/augeas/_augeas.c
+++ b/ext/augeas/_augeas.c
@@ -519,7 +519,10 @@ void Init__augeas() {
     DEF_AUG_ERR(ENOLENS);
     DEF_AUG_ERR(EMXFM);
     DEF_AUG_ERR(ENOSPAN);
+    DEF_AUG_ERR(EMVDESC);
     DEF_AUG_ERR(ECMDRUN);
+    DEF_AUG_ERR(EBADARG);
+    DEF_AUG_ERR(ELABEL);
 #undef DEF_AUG_ERR
 
     /* Define the methods */

--- a/ext/augeas/_augeas.c
+++ b/ext/augeas/_augeas.c
@@ -51,11 +51,34 @@ static void augeas_free(augeas *aug) {
 VALUE augeas_get(VALUE s, VALUE path) {
     augeas *aug = aug_handle(s);
     const char *cpath = StringValueCStr(path);
-    const char *value;
+    const char *value = NULL;
 
-    aug_get(aug, cpath, &value);
-    if (value != NULL) {
+    int r = aug_get(aug, cpath, &value);
+    /* There used to be a bug in Augeas that would make it not properly set
+     * VALUE to NULL when PATH was invalid. We check RETVAL, too, to avoid
+     * running into that */
+    if (r == 1 && value != NULL) {
         return rb_str_new(value, strlen(value)) ;
+    } else {
+        return Qnil;
+    }
+}
+
+/*
+ * call-seq:
+ *   get(PATH) -> String
+ *
+ * Lookup the value associated with PATH
+ */
+VALUE facade_get(VALUE s, VALUE path) {
+    augeas *aug = aug_handle(s);
+    const char *cpath = StringValueCStr(path);
+    const char *value = NULL;
+
+    int retval = aug_get(aug, cpath, &value);
+
+    if (retval == 1 && value != NULL) {
+        return rb_str_new(value, strlen(value));
     } else {
         return Qnil;
     }

--- a/lib/augeas/facade.rb
+++ b/lib/augeas/facade.rb
@@ -1,0 +1,326 @@
+# -*- coding: utf-8 -*-
+##
+#  augeas.rb: Ruby wrapper for augeas
+#
+#  Copyright (C) 2008 Red Hat Inc.
+#  Copyright (C) 2011 SUSE LINUX Products GmbH, Nuernberg, Germany.
+#
+#  This library is free software; you can redistribute it and/or
+#  modify it under the terms of the GNU Lesser General Public
+#  License as published by the Free Software Foundation; either
+#  version 2.1 of the License, or (at your option) any later version.
+#
+#  This library is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+#  Lesser General Public License for more details.
+#
+#  You should have received a copy of the GNU Lesser General Public
+#  License along with this library; if not, write to the Free Software
+#  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307  USA
+#
+# Authors: Ionuț Arțăriși <iartarisi@suse.cz>
+#          Bryan Kearney <bkearney@redhat.com>
+#          Artem Sheremet <dot.doom@gmail.com>
+##
+
+# Do not require this file explicitly; instead require "augeas"
+
+# Wrapper class for the augeas[http://augeas.net] library.
+class Augeas::Facade
+  private_class_method :new
+
+  def self.create(opts={}, &block)
+    # aug_flags is a bitmask in the underlying library, we add all the
+    # values of the flags which were set to true to the default value
+    # Augeas::NONE (which is 0)
+    aug_flags = defined?(Augeas::NO_ERR_CLOSE) ? Augeas::NO_ERR_CLOSE : Augeas::NONE
+
+    flags = {
+      :type_check => Augeas::TYPE_CHECK,
+      :no_stdinc => Augeas::NO_STDINC,
+      :no_load => Augeas::NO_LOAD,
+      :no_modl_autoload => Augeas::NO_MODL_AUTOLOAD,
+      :enable_span => Augeas::ENABLE_SPAN
+    }
+    save_modes = {
+      :backup => Augeas::SAVE_BACKUP,
+      :newfile => Augeas::SAVE_NEWFILE,
+      :noop => Augeas::SAVE_NOOP
+    }
+    opts.each_key do |key|
+      if flags.key? key
+        aug_flags |= flags[key]
+      elsif key == :save_mode
+        if save_modes[opts[:save_mode]]
+          aug_flags |= save_modes[opts[:save_mode]]
+        else
+          raise ArgumentError, "Invalid save mode #{opts[:save_mode]}."
+        end
+      elsif key != :root && key != :loadpath
+        raise ArgumentError, "Unknown argument #{key}."
+      end
+    end
+
+    aug = Augeas::Facade::open3(opts[:root], opts[:loadpath], aug_flags)
+
+    begin
+      aug.send(:raise_last_error)
+    rescue
+      aug.close
+      raise
+    end
+
+    if block_given?
+      begin
+        yield aug
+      ensure
+        aug.close
+      end
+    else
+      return aug
+    end
+  end
+
+  # Get the value associated with +path+.
+  def get(path)
+    run_command :augeas_get, path
+  end
+
+  # Return true if there is an entry for this path, false otherwise
+  def exists(path)
+    run_command :augeas_exists, path
+  end
+
+  # Set one or multiple elements to path.
+  # Multiple elements are mainly sensible with a path like
+  # .../array[last()+1], since this will append all elements.
+  def set(path, *values)
+    values.flatten.each { |v| run_command :augeas_set, path, v }
+  end
+
+  # Set multiple nodes in one operation.  Find or create a node matching SUB
+  # by interpreting SUB as a  path expression relative to each node matching
+  # BASE. If SUB is '.', the nodes matching BASE will be modified.
+
+  # +base+    the base node
+  # +sub+     the subtree relative to the base
+  # +value+   the value for the nodes
+  def setm(base, sub, value)
+    run_command :augeas_setm, base, sub, value
+  end
+
+  # Remove all nodes matching path expression +path+ and all their
+  # children.
+  # Raises an <tt>Augeas::InvalidPathError</tt> when the +path+ is invalid.
+  def rm(path)
+    run_command :augeas_rm, path
+  end
+
+  # Return an Array of all the paths that match the path expression +path+
+  #
+  # Returns an empty Array if no paths were found.
+  # Raises an <tt>Augeas::InvalidPathError</tt> when the +path+ is invalid.
+  def match(path)
+    run_command :augeas_match, path
+  end
+
+  # Create the +path+ with empty value if it doesn't exist
+  def touch(path)
+    set(path, nil) if match(path).empty?
+  end
+
+  # Evaluate +expr+ and set the variable +name+ to the resulting
+  # nodeset. The variable can be used in path expressions as $name.
+  # Note that +expr+ is evaluated when the variable is defined, not when
+  # it is used.
+  def defvar(name, expr)
+    run_command :augeas_defvar, name, expr
+  end
+
+  # Define the variable +name+ to the result of evaluating +expr+, which
+  # must be a nodeset.  If no node matching +expr+ exists yet, one is
+  # created and +name+ will refer to it.  When a node is created and
+  # +value+ is given, the new node's value is set to +value+.
+  def defnode(name, expr, value=nil)
+    run_command :augeas_defnode, name, expr, value
+  end
+
+  # Clear the +path+, i.e. make its value +nil+
+  def clear(path)
+    augeas_set(path, nil)
+  end
+
+  # Add a transform under <tt>/augeas/load</tt>
+  #
+  # The HASH can contain the following entries
+  # * <tt>:lens</tt> - the name of the lens to use
+  # * <tt>:name</tt> - a unique name; use the module name of the LENS
+  # when omitted
+  # * <tt>:incl</tt> - a list of glob patterns for the files to transform
+  # * <tt>:excl</tt> - a list of the glob patterns to remove from the
+  # list that matches <tt>:incl</tt>
+  def transform(hash)
+    lens = hash[:lens]
+    name = hash[:name]
+    incl = hash[:incl]
+    excl = hash[:excl]
+    raise ArgumentError, "No lens specified" unless lens
+    raise ArgumentError, "No files to include" unless incl
+    name = lens.split(".")[0].sub("@", "") unless name
+
+    xfm = "/augeas/load/#{name}/"
+    set(xfm + "lens", lens)
+    set(xfm + "incl[last()+1]", incl)
+    set(xfm + "excl[last()+1]", excl) if excl
+  end
+
+  # Clear all transforms under <tt>/augeas/load</tt>. If +load+
+  # is called right after this, there will be no files
+  # under +/files+
+  def clear_transforms
+    rm("/augeas/load/*")
+  end
+
+  # Write all pending changes to disk.
+  # Raises <tt>Augeas::CommandExecutionError</tt> if saving fails.
+  def save
+    begin
+      run_command :augeas_save
+    rescue Augeas::CommandExecutionError => e
+      raise e, 'Saving failed. Search the augeas tree in /augeas//error ' <<
+        'for the actual errors.'
+    end
+
+    nil
+  end
+
+  def clearm(path, sub)
+    setm(path, sub, nil)
+  end
+
+  # Load files according to the transforms in /augeas/load or those
+  # defined via <tt>transform</tt>.  A transform Foo is represented
+  # with a subtree /augeas/load/Foo.  Underneath /augeas/load/Foo, one
+  # node labeled 'lens' must exist, whose value is the fully
+  # qualified name of a lens, for example 'Foo.lns', and multiple
+  # nodes 'incl' and 'excl' whose values are globs that determine
+  # which files are transformed by that lens. It is an error if one
+  # file can be processed by multiple transforms.
+  def load
+    begin
+      run_command :augeas_load
+    rescue Augeas::CommandExecutionError => e
+      raise e, "Loading failed. Search the augeas tree in /augeas//error"+
+        "for the actual errors."
+    end
+
+    nil
+  end
+
+  # Move node +src+ to +dst+. +src+ must match exactly one node in
+  # the tree. +dst+ must either match exactly one node in the tree,
+  # or may not exist yet. If +dst+ exists already, it and all its
+  # descendants are deleted. If +dst+ does not exist yet, it and all
+  # its missing ancestors are created.
+  #
+  # Raises <tt>Augeas::NoMatchError</tt> if the +src+ node does not exist
+  # Raises <tt>Augeas::MultipleMatchesError</tt> if there were
+  # multiple matches in +src+
+  # Raises <tt>Augeas::DescendantError</tt> if the +dst+ node is a
+  # descendant of the +src+ node.
+  def mv(src, dst)
+    run_command :augeas_mv, src, dst
+  end
+
+  # Get the filename, label and value position in the text of this node
+  #
+  # Raises <tt>Augeas::NoMatchError</tt> if the node could not be found
+  # Raises <tt>Augeas::NoSpanInfo</tt> if the node associated with
+  # +path+ doesn't belong to a file or doesn't exist
+  def span(path)
+    run_command :augeas_span, path
+  end
+
+  # Run one or more newline-separated commands specified by +text+,
+  # returns an array of [successful_commands_number, output] or
+  # [-2, output] in case 'quit' command has been encountered.
+  # Raises <tt>Augeas::CommandExecutionError</tt> if gets an invalid command
+  def srun(text)
+    run_command(:augeas_srun, text)
+  end
+
+  # Lookup the label associated with +path+
+  # Raises <tt>Augeas::NoMatchError</tt> if the +path+ node does not exist
+  def label(path)
+    run_command :augeas_label, path
+  end
+
+  # Rename the label of all nodes matching +path+ to +label+
+  # Raises <tt>Augeas::NoMatchError</tt> if the +path+ node does not exist
+  # Raises <tt>Augeas::InvalidLabelError</tt> if +label+ is invalid
+  def rename(path, label)
+    run_command :augeas_rename, path, label
+  end
+
+  # Use the value of node +node+ as a string and transform it into a tree
+  # using the lens +lens+ and store it in the tree at +path+,
+  # which will be overwritten. +path+ and +node+ are path expressions.
+  def text_store(lens, node, path)
+    run_command :augeas_text_store, lens, node, path
+  end
+
+  # Transform the tree at +path+ into a string lens +lens+ and store it
+  # in the node +node_out+, assuming the tree was initially generated using
+  # the value of node +node_in+. +path+, +node_in+ and +node_out+ are path expressions.
+  def text_retrieve(lens, node_in, path, node_out)
+    run_command :augeas_text_retrieve, lens, node_in, path, node_out
+  end
+
+  # Make +label+ a sibling of +path+ by inserting it directly before
+  # or after +path+.
+  # The boolean +before+ determines if +label+ is inserted before or
+  # after +path+.
+  def insert(path, label, before)
+    run_command :augeas_insert, path, label, before
+  end
+
+  # Set path expression context to +path+ (in /augeas/context)
+  def context=(path)
+    set('/augeas/context', path)
+  end
+
+  # Get path expression context (from /augeas/context)
+  def context
+    get('/augeas/context')
+  end
+
+  private
+
+  # Run a command and raise any errors that happen due to execution.
+  #
+  # +cmd+ name of the Augeas command to run
+  # +params+ parameters with which +cmd+ will be called
+  #
+  # Returns whatever the original +cmd+ returns
+  def run_command(cmd, *params)
+    result = self.send cmd, *params
+
+    raise_last_error
+
+    if result.kind_of? Fixnum and result < 0
+      # we raise CommandExecutionError here, because this is the error that
+      # augtool raises in this case as well
+      raise Augeas::CommandExecutionError, "Command failed. Return code was #{result}."
+    end
+
+    return result
+  end
+
+  def raise_last_error
+    error_cache = error
+    unless error_cache[:code].zero?
+      raise Augeas::ERRORS_HASH[error_cache[:code]], "#{error_cache[:message]} #{error_cache[:details]}"
+    end
+  end
+end

--- a/tests/tc_augeas.rb
+++ b/tests/tc_augeas.rb
@@ -1,6 +1,8 @@
 require 'test/unit'
 
-TOPDIR = File::expand_path(File::join(File::dirname(__FILE__), ".."))
+unless defined?(TOPDIR)
+  TOPDIR = File::expand_path(File::join(File::dirname(__FILE__), ".."))
+end
 
 $:.unshift(File::join(TOPDIR, "lib"))
 $:.unshift(File::join(TOPDIR, "ext", "augeas"))

--- a/tests/tc_facade.rb
+++ b/tests/tc_facade.rb
@@ -1,0 +1,554 @@
+# -*- coding: utf-8 -*-
+##
+#  Augeas tests
+#
+#  Copyright (C) 2011 Red Hat Inc.
+#  Copyright (C) 2011 SUSE LINUX Products GmbH, Nuernberg, Germany.
+#
+#  This library is free software; you can redistribute it and/or
+#  modify it under the terms of the GNU Lesser General Public
+#  License as published by the Free Software Foundation; either
+#  version 2.1 of the License, or (at your option) any later version.
+#
+#  This library is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+#  Lesser General Public License for more details.
+#
+#  You should have received a copy of the GNU Lesser General Public
+#  License along with this library; if not, write to the Free Software
+#  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307  USA
+#
+# Authors: David Lutterkort <dlutter@redhat.com>
+#          Ionuț Arțăriși <iartarisi@suse.cz>
+##
+
+require 'test/unit'
+
+unless defined?(TOPDIR)
+  TOPDIR = File::expand_path(File::join(File::dirname(__FILE__), ".."))
+end
+
+$:.unshift(File::join(TOPDIR, "lib"))
+$:.unshift(File::join(TOPDIR, "ext", "augeas"))
+
+require 'augeas'
+require 'fileutils'
+
+class TestAugeasFacade < Test::Unit::TestCase
+
+	SRC_ROOT = File::expand_path(File::join(TOPDIR, "tests", "root")) + "/."
+	TST_ROOT = File::expand_path(File::join(TOPDIR, "build", "root")) + "/"
+
+	def test_basics
+		aug = aug_create(:save_mode => :newfile)
+		assert_equal("newfile", aug.get("/augeas/save"))
+		assert_equal(TST_ROOT, aug.get("/augeas/root"))
+
+		assert(aug.exists("/augeas/root"))
+		assert_not_nil(aug.get("/augeas/root"))
+		node = "/ruby/test/node"
+		assert_nothing_raised {
+			aug.set(node, "value")
+		}
+		assert_equal("value", aug.get(node))
+		assert_nothing_raised {
+			aug.clear(node)
+		}
+		assert_equal(nil, aug.get(node))
+		m = aug.match("/*")
+		["/augeas", "/ruby"].each do |p|
+			assert(m.include?(p))
+			assert(aug.exists(p))
+		end
+	end
+
+	def test_no_new
+		assert_raise NoMethodError do
+			Augeas.new
+		end
+	end
+
+	def test_create_unknown_argument
+		assert_raise ArgumentError do
+			Augeas::create(:bogus => false)
+		end
+	end
+
+	def test_create_invalid_save_mode
+		assert_raise ArgumentError do
+			Augeas::create(:save_mode => :bogus)
+		end
+	end
+
+	def test_create_block
+		foo = nil
+		Augeas::create do |aug|
+			aug.set('/foo', 'bar')
+			foo = aug.get('/foo')
+		end
+		assert_equal(foo, 'bar')
+	end
+
+	def test_close
+		aug = Augeas::create(:root => "/tmp", :save_mode => :newfile)
+		assert_equal("newfile", aug.get("/augeas/save"))
+		aug.close
+
+		assert_raise(SystemCallError) {
+			aug.get("/augeas/save")
+		}
+
+		assert_raise(SystemCallError) {
+			aug.close
+		}
+	end
+
+	def test_mv
+		Augeas::create(:root => "/dev/null") do |aug|
+			aug.set("/a/b", "value")
+			aug.mv("/a/b", "/x/y")
+			assert_equal("value", aug.get("/x/y"))
+		end
+	end
+
+	def test_mv_descendent_error
+		aug = aug_create
+		aug.set("/foo", "bar")
+		assert_raises(Augeas::DescendantError) {aug.mv("/foo", "/foo/bar/baz")}
+	end
+
+	def test_mv_multiple_matches_error
+		aug = aug_create
+		aug.set("/foo/bar", "bar")
+		aug.set("/foo/baz", "baz")
+		assert_raises(Augeas::MultipleMatchesError) {aug.mv("/foo/*", "/qux")}
+	end
+
+	def test_mv_invalid_path_error
+		aug = aug_create
+		assert_raises(Augeas::InvalidPathError) {aug.mv("/foo", "[]")}
+	end
+
+	def test_mv_no_match_error
+		aug = aug_create
+		assert_raises(Augeas::NoMatchError) {aug.mv("/nonexistent", "/")}
+	end
+
+	def test_mv_mutiple_dest_error
+		aug = aug_create
+		aug.set("/foo", "bar")
+		assert_raises(Augeas::CommandExecutionError) {aug.mv("/foo", "/bar/baz/*")}
+	end
+
+	def test_load
+		aug = aug_create(:no_load => true)
+		assert_equal([], aug.match("/files/etc/*"))
+		aug.rm("/augeas/load/*");
+		assert_nothing_raised {
+			aug.load
+		}
+		assert_equal([], aug.match("/files/etc/*"))
+	end
+
+	def test_load_bad_lens
+		aug = aug_create(:no_load => true)
+		aug.transform(:lens => "bad_lens", :incl => "irrelevant")
+		assert_raises(Augeas::LensNotFoundError) { aug.load }
+		assert_equal "Can not find lens bad_lens", aug.error[:details]
+	end
+
+	def test_transform
+		aug = aug_create(:no_load => true)
+		aug.clear_transforms
+		aug.transform(:lens => "Hosts.lns",
+					  :incl => "/etc/hosts")
+		assert_raise(ArgumentError) {
+			aug.transform(:name => "Fstab",
+						  :incl => [ "/etc/fstab" ],
+						  :excl => [ "*~", "*.rpmnew" ])
+		}
+		aug.transform(:lens => "Inittab.lns",
+					  :incl => "/etc/inittab")
+		aug.transform(:lens => "Fstab.lns",
+					  :incl => "/etc/fstab*",
+					  :excl => "*~")
+		assert_equal(["/augeas/load/Fstab", "/augeas/load/Fstab/excl",
+				"/augeas/load/Fstab/incl", "/augeas/load/Fstab/lens",
+				"/augeas/load/Hosts", "/augeas/load/Hosts/incl",
+				"/augeas/load/Hosts/lens", "/augeas/load/Inittab",
+				"/augeas/load/Inittab/incl",
+				"/augeas/load/Inittab/lens"],
+				aug.match("/augeas/load//*").sort)
+		aug.load
+		assert_equal(["/files/etc/hosts", "/files/etc/inittab"],
+					 aug.match("/files/etc/*").sort)
+	end
+
+	def test_transform_invalid_path
+		aug = aug_create
+		assert_raises (Augeas::InvalidPathError) {
+			aug.transform :lens => '//', :incl => 'foo' }
+	end
+
+	def test_clear_transforms
+		aug = aug_create
+		assert_not_equal [], aug.match("/augeas/load/*")
+		aug.clear_transforms
+		assert_equal [], aug.match("/augeas/load/*")
+	end
+
+	def test_clear
+		aug = aug_create
+		aug.set("/foo/bar", "baz")
+		aug.clear("/foo/bar")
+		assert_equal aug.get("/foo/bar"), nil
+	end
+
+	def test_rm
+		aug = aug_create
+		aug.set("/foo/bar", "baz")
+		assert aug.get("/foo/bar")
+		assert_equal 2, aug.rm("/foo")
+		assert_nil aug.get("/foo")
+	end
+
+	def test_rm_invalid_path
+		aug = aug_create
+		assert_raises(Augeas::InvalidPathError) { aug.rm('//') }
+	end
+
+	def test_defvar
+		Augeas::create(:root => "/dev/null") do |aug|
+			aug.set("/a/b", "bval")
+			aug.set("/a/c", "cval")
+			assert aug.defvar("var", "/a/b")
+			assert_equal(["/a/b"], aug.match("$var"))
+			assert aug.defvar("var", nil)
+			assert_raises(Augeas::InvalidPathError) {
+				aug.match("$var")
+			}
+			assert_raises(Augeas::InvalidPathError) {
+				aug.defvar("var", "/foo/")
+			}
+		end
+	end
+
+	def test_insert_before
+		aug = aug_create
+		aug.set("/parent/child", "foo")
+		aug.insert("/parent/child", "sibling", true)
+		assert_equal ["/parent/sibling", "/parent/child"], aug.match("/parent/*")
+	end
+
+	def test_insert_after
+		aug = aug_create
+		aug.set("/parent/child", "foo")
+		aug.insert("/parent/child", "sibling", false)
+		assert_equal ["/parent/child", "/parent/sibling"], aug.match("/parent/*")
+	end
+
+	def test_insert_no_match
+		aug = aug_create
+		assert_raises (Augeas::NoMatchError) { aug.insert "foo", "bar", "baz" }
+	end
+
+	def test_insert_invalid_path
+		aug = aug_create
+		assert_raises (Augeas::InvalidPathError) { aug.insert "//", "bar", "baz" }
+	end
+
+	def test_insert_too_many_matches
+		aug = aug_create
+		assert_raises (Augeas::MultipleMatchesError) { aug.insert "/*", "a", "b" }
+	end
+
+	def test_match
+		aug = aug_create
+		aug.set("/foo/bar", "baz")
+		aug.set("/foo/baz", "qux")
+		aug.set("/foo/qux", "bar")
+
+		assert_equal(["/foo/bar", "/foo/baz", "/foo/qux"], aug.match("/foo/*"))
+	end
+
+	def test_match_empty_list
+		aug = aug_create
+		assert_equal([], aug.match("/nonexistent"))
+	end
+
+	def test_match_invalid_path
+		aug = aug_create
+		assert_raises(Augeas::InvalidPathError) { aug.match('//') }
+	end
+
+	def test_save
+		aug = aug_create
+		aug.set("/files/etc/hosts/1/garbage", "trash")
+		assert_raises(Augeas::CommandExecutionError) { aug.save }
+	end
+
+	def test_save_tree_error
+		aug = aug_create(:no_load => true)
+		aug.set("/files/etc/sysconfig/iptables", "bad")
+		assert_raises(Augeas::CommandExecutionError) {aug.save}
+		assert aug.get("/augeas/files/etc/sysconfig/iptables/error")
+		assert_equal("No such file or directory",
+					 aug.get("/augeas/files/etc/sysconfig/iptables/error/message"))
+	end
+
+	def test_set_invalid_path
+		aug = aug_create
+		assert_raises(Augeas::InvalidPathError) { aug.set("files/etc//", nil) }
+	end
+
+	def test_set_multiple_matches_error
+		aug = aug_create
+		# for some reason Augeas does not set aug_error for this,
+		# but just returns -1 from aug_set. Should raise Augeas::MultipleMatchesError instead.
+		assert_raises(Augeas::CommandExecutionError) { aug.set("files/etc/*", nil) }
+	end
+
+	def test_set
+		aug = aug_create
+		aug.set("/files/etc/group/disk/user[last()+1]",["user1","user2"])
+		assert_equal(aug.get("/files/etc/group/disk/user[1]"), "root")
+		assert_equal(aug.get("/files/etc/group/disk/user[2]"), "user1")
+		assert_equal(aug.get("/files/etc/group/disk/user[3]"), "user2")
+
+		aug.set("/files/etc/group/new_group/user[last()+1]",
+				"nuser1",["nuser2","nuser3"])
+		assert_equal(aug.get("/files/etc/group/new_group/user[1]"), "nuser1")
+		assert_equal(aug.get("/files/etc/group/new_group/user[2]"), "nuser2")
+		assert_equal(aug.get("/files/etc/group/new_group/user[3]"), "nuser3")
+
+		aug.rm("/files/etc/group/disk/user")
+		aug.set("/files/etc/group/disk/user[last()+1]", "testuser")
+		assert_equal(aug.get("/files/etc/group/disk/user"), "testuser")
+
+		aug.rm("/files/etc/group/disk/user")
+		aug.set("/files/etc/group/disk/user[last()+1]", nil)
+		assert_equal(aug.get("/files/etc/group/disk/user"), nil)
+	end
+
+	def test_setm_invalid_path
+		aug = aug_create
+		assert_raises (Augeas::InvalidPathError) { aug.setm("[]", "bar", "baz") }
+	end
+
+	def test_exists
+		aug = aug_create
+		assert_equal false, aug.exists("/foo")
+		aug.set("/foo", "bar")
+		assert aug.exists("/foo")
+	end
+
+	def test_exists_invalid_path_error
+		aug = aug_create
+		assert_raises(Augeas::InvalidPathError) {aug.exists("[]")}
+	end
+
+	def test_get_multiple_matches_error
+		aug = aug_create
+
+		# Cause an error
+		assert_raises (Augeas::MultipleMatchesError) {
+			aug.get("/files/etc/hosts/*") }
+
+		err = aug.error
+		assert_equal(Augeas::EMMATCH, err[:code])
+		assert err[:message]
+		assert err[:details]
+		assert err[:minor].nil?
+	end
+
+	def test_get_invalid_path
+		aug = aug_create
+		assert_raises (Augeas::InvalidPathError) { aug.get("//") }
+
+		err = aug.error
+		assert_equal(Augeas::EPATHX, err[:code])
+		assert err[:message]
+		assert err[:details]
+	end
+
+	def test_defvar_invalid_path
+		aug = aug_create
+		assert_raises(Augeas::InvalidPathError) { aug.defvar('var', 'F#@!$#@') }
+	end
+
+	def test_defnode
+		aug = aug_create
+		assert aug.defnode("x", "/files/etc/hosts/*[ipaddr = '127.0.0.1']", nil)
+		assert_equal(["/files/etc/hosts/1"], aug.match("$x"))
+	end
+
+	def test_defnode_invalid_path
+		aug = aug_create
+		assert_raises (Augeas::InvalidPathError) { aug.defnode('x', '//', nil)}
+	end
+
+	def test_span_no_span_info
+		aug = aug_create
+		# this error should be raised because we haven't enabled the span
+		assert_raises(Augeas::NoSpanInfoError) {
+			aug.span("/files/etc/ssh/sshd_config/Protocol") }
+	end
+
+	def test_span_no_matches
+		aug = aug_create
+		assert_raises(Augeas::NoMatchError) { aug.span("bogus") }
+	end
+
+	def test_flag_save_noop
+		aug = aug_create(:save_mode => :noop)
+		assert_equal("noop", aug.get("/augeas/save"))
+	end
+
+	def test_flag_no_load
+		aug = aug_create(:no_load => true)
+		assert_equal([], aug.match("/files/*"))
+	end
+
+	def test_flag_no_modl_autoload
+		aug = aug_create(:no_modl_autoload => true)
+		assert_equal([], aug.match("/files/*"))
+	end
+
+	def test_flag_enable_span
+		aug = aug_create(:enable_span => true)
+		assert_equal("enable", aug.get("/augeas/span"))
+	end
+
+	def test_setm
+		aug = aug_create
+
+		aug.setm("/files/etc/group/*[label() =~ regexp(\"rpc.*\")]","users", "testuser1")
+		assert_equal( aug.get("/files/etc/group/rpc/users"), "testuser1")
+		assert_equal( aug.get("/files/etc/group/rpcuser/users"), "testuser1")
+
+		aug.setm("/files/etc/group/*[label() =~ regexp(\"rpc.*\")]/users",nil, "testuser2")
+		assert_equal( aug.get("/files/etc/group/rpc/users"), "testuser2")
+		assert_equal( aug.get("/files/etc/group/rpcuser/users"), "testuser2")
+	end
+
+	def test_error
+		aug = aug_create
+
+		# Cause an error
+		aug.get("/files/etc/hosts/*") rescue nil
+		err = aug.error
+		assert_equal(Augeas::EMMATCH, err[:code])
+		assert err[:message]
+		assert err[:details]
+		assert err[:minor].nil?
+	end
+
+	def test_span
+		aug = aug_create
+
+		assert_raises(Augeas::NoSpanInfoError) { aug.span("/files/etc/ssh/sshd_config/Protocol") }
+
+		aug.set("/augeas/span", "enable")
+		aug.rm("/files/etc")
+		aug.load
+
+		span = aug.span("/files/etc/ssh/sshd_config/Protocol")
+		assert_not_nil(span[:filename])
+		assert_equal(29..37, span[:label])
+		assert_equal(38..39, span[:value])
+		assert_equal(29..40, span[:span])
+	end
+
+	def test_srun
+		aug = aug_create
+
+		path = "/files/etc/hosts/*[canonical='localhost.localdomain']/ipaddr"
+		r, out = aug.srun("get #{path}\n")
+		assert_equal(1, r)
+		assert_equal("#{path} = 127.0.0.1\n", out)
+
+		assert_equal(0, aug.srun(" ")[0])
+		assert_raises(Augeas::CommandExecutionError) { aug.srun("foo") }
+		assert_raises(Augeas::CommandExecutionError) { aug.srun("set") }
+		assert_equal(-2, aug.srun("quit")[0])
+	end
+
+	def test_label
+		Augeas::create(:root => "/dev/null") do |aug|
+			assert_equal 'augeas', aug.label('/augeas')
+			assert_equal 'files', aug.label('/files')
+		end
+	end
+
+	def test_rename
+		Augeas::create(:root => "/dev/null") do |aug|
+			assert_raises(Augeas::InvalidLabelError) { aug.rename('/files', 'invalid/label') }
+			assert_equal 0, aug.rename('/nonexistent', 'label')
+			assert_equal ['/files'], aug.match('/files')
+			assert_equal 1, aug.rename('/files', 'label')
+		end
+	end
+
+	def test_text_store_retrieve
+		Augeas::create(:root => "/dev/null") do |aug|
+			# text_store errors
+			assert_raises(Augeas::NoMatchError) { aug.text_store('Simplelines.lns', '/input', '/store') }
+
+			# text_store
+			aug.set('/input', "line1\nline2\n")
+			assert aug.text_store('Simplelines.lns', '/input', '/store')
+			assert_equal 'line2', aug.get('/store/2')
+
+			# text_retrieve errors
+			assert_raises(Augeas::NoMatchError) { aug.text_retrieve('Simplelines.lns', '/unknown', '/store', '/output') }
+
+			# text_retrieve
+			aug.set('/store/3', 'line3')
+			assert aug.text_retrieve('Simplelines.lns', '/input', '/store', '/output')
+			assert_equal "line1\nline2\nline3\n", aug.get('/output')
+		end
+	end
+
+	def test_context
+		Augeas::create(:root => "/dev/null") do |aug|
+			aug.context = '/augeas'
+			assert_equal '/augeas', aug.get('/augeas/context')
+			assert_equal '/augeas', aug.get('context')
+			assert_equal '/augeas', aug.context
+		end
+	end
+
+	def test_touch
+		Augeas::create(:root => "/dev/null") do |aug|
+			assert_equal [], aug.match('/foo')
+			aug.touch '/foo'
+			assert_equal ['/foo'], aug.match('/foo')
+
+			aug.set '/foo', 'bar'
+			aug.touch '/foo'
+			assert_equal 'bar', aug.get('/foo')
+		end
+	end
+
+	def test_clearm
+		Augeas::create(:root => "/dev/null") do |aug|
+			aug.set('/foo/a', '1')
+			aug.set('/foo/b', '2')
+			aug.clearm('/foo', '*')
+			assert_nil aug.get('/foo/a')
+			assert_nil aug.get('/foo/b')
+		end
+	end
+
+	private
+	def aug_create(flags={})
+		if File::directory?(TST_ROOT)
+			FileUtils::rm_rf(TST_ROOT)
+		end
+		FileUtils::mkdir_p(TST_ROOT)
+		FileUtils::cp_r(SRC_ROOT, TST_ROOT)
+
+		Augeas::create({:root => TST_ROOT, :loadpath => nil}.merge(flags))
+	end
+end


### PR DESCRIPTION
These changes add a `Augeas::create` method that sets up the more Rubyish API that have been proposed in PR #1 and PR #2 in a way that does not change the existing API at all.

Note that these changes go on top of PR #7 