### PR TITLE
Fix Ruby 3.2 warning about undefined allocator

### DIFF
--- a/ext/augeas/_augeas.c
+++ b/ext/augeas/_augeas.c
@@ -558,7 +558,9 @@ void Init__augeas() {
 
     /* Define the ruby class */
     c_augeas = rb_define_class("Augeas", rb_cObject) ;
+    rb_undef_alloc_func(c_augeas);
     c_facade = rb_define_class_under(c_augeas, "Facade", rb_cObject);
+    rb_undef_alloc_func(c_facade);
 
     /* Constants for enum aug_flags */
 #define DEF_AUG_FLAG(name) \


### PR DESCRIPTION
This fixes 'warning: undefining the allocator of T_DATA class Augeas' which Ruby 3.2 started to warn about.

See https://bugs.ruby-lang.org/issues/18007 for more information.

Fixes #13