### PR TITLE
Add CI using GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,35 @@
+---
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+
+jobs:
+  ruby:
+    name: 'Ruby ${{ matrix.ruby }}'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby:
+          - '3.3'
+          - '3.2'
+          - '3.1'
+          - '3.0'
+          - '2.7'
+    steps:
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libaugeas-dev
+      - uses: actions/checkout@v4
+      - name: Setup ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
+      - name: Run tests
+        run: bundle exec rake test

--- a/lib/augeas/facade.rb
+++ b/lib/augeas/facade.rb
@@ -308,7 +308,7 @@ class Augeas::Facade
 
     raise_last_error
 
-    if result.kind_of? Fixnum and result < 0
+    if result.kind_of? Integer and result < 0
       # we raise CommandExecutionError here, because this is the error that
       # augtool raises in this case as well
       raise Augeas::CommandExecutionError, "Command failed. Return code was #{result}."


### PR DESCRIPTION
This includes https://github.com/hercules-team/ruby-augeas/pull/15 since otherwise it would fail a lot more. Now it still fails one test.

Initially I wanted to know if the [FTBFS error in Fedora 40](https://bugzilla.redhat.com/show_bug.cgi?id=2261659) was because of Ruby 3.3 but then I also saw the same message as a warning on Fedora 38. That makes me think the compiler in Fedora 40 makes the warning a fatal error.