### PR TITLE
Remove unused sibling argument from augeas_rm

### DIFF
--- a/ext/augeas/_augeas.c
+++ b/ext/augeas/_augeas.c
@@ -184,7 +184,7 @@ VALUE augeas_mv(VALUE s, VALUE src, VALUE dst) {
  *
  * Remove path and all its children. Returns the number of entries removed
  */
-VALUE augeas_rm(VALUE s, VALUE path, VALUE sibling) {
+VALUE augeas_rm(VALUE s, VALUE path) {
     augeas *aug = aug_handle(s);
     const char *cpath = StringValueCStr(path) ;
 


### PR DESCRIPTION
This makes the function match the method definition. There was already a warning about this, but Fedora 40 applies more hardening and it's a fatal error.

```
gcc -I. -I/usr/include -I/usr/include/ruby/backward -I/usr/include -I. -I/usr/include/libxml2 -I/usr/include/libxml2   -fPIC -O2 -flto=auto -ffat-lto-objects -fexceptions -g -grecord-gcc-switches -pipe -Wall -Wno-complain-wrong-lang -Werror=format-security -Wp,-U_FORTIFY_SOURCE,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -fstack-protector-strong -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1  -m64 -march=z13 -mtune=z14 -fasynchronous-unwind-tables -fstack-clash-protection -DWITH_GZFILEOP -DWITH_GZFILEOP -m64 -o _augeas.o -c _augeas.c
_augeas.c: In function ‘Init__augeas’:
_augeas.c:531:5: error: passing argument 3 of ‘rb_define_method_01’ from incompatible pointer type [-Wincompatible-pointer-types]
  531 |     rb_define_method(c_augeas, "rm", augeas_rm, 1);
      |     ^~~~~~~~~~~~~~~~
      |     |
      |     VALUE (*)(VALUE,  VALUE,  VALUE) {aka long unsigned int (*)(long unsigned int,  long unsigned int,  long unsigned int)}
In file included from /usr/include/ruby/ruby.h:27,
                 from /usr/include/ruby.h:38,
                 from _augeas.h:21,
                 from _augeas.c:22:
/usr/include/ruby/internal/anyargs.h:277:1: note: expected ‘VALUE (*)(VALUE,  VALUE)’ {aka ‘long unsigned int (*)(long unsigned int,  long unsigned int)’} but argument is of type ‘VALUE (*)(VALUE,  VALUE,  VALUE)’ {aka ‘long unsigned int (*)(long unsigned int,  long unsigned int,  long unsigned int)’}
  277 | RBIMPL_ANYARGS_DECL(rb_define_method, VALUE, const char *)
      | ^~~~~~~~~~~~~~~~~~~
make: *** [Makefile:249: _augeas.o] Error 1
```

Fixes: e6b57c58d24b ("Initial ruby bindings, written by Bryan Kearney")