### PR TITLE
Run all tests in gemspec

### DIFF
--- a/ruby-augeas.spec
+++ b/ruby-augeas.spec
@@ -40,7 +40,7 @@ install -p -m0644 lib/augeas.rb %{buildroot}%{ruby_vendorlibdir}
 install -p -m0755 ext/augeas/_augeas.so %{buildroot}%{ruby_vendorarchdir}
 
 %check
-ruby tests/tc_augeas.rb
+rake test
 
 
 %files


### PR DESCRIPTION
While updating the ruby-augeas spec in Fedora I noticed that a new test was added. This makes sure all the tests run.